### PR TITLE
Logic error that could result in a NPE

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -10043,7 +10043,7 @@ public class PackageManagerService extends IPackageManager.Stub {
             ArrayList<IntentFilter> result = new ArrayList<>();
             for (int n=0; n<count; n++) {
                 PackageParser.Activity activity = pkg.activities.get(n);
-                if (activity.intents != null || activity.intents.size() > 0) {
+                if (activity.intents != null && activity.intents.size() > 0) {
                     result.addAll(activity.intents);
                 }
             }


### PR DESCRIPTION
Here if activity.intents == null, we would invoke activity.intents.size() resulting in NPE.